### PR TITLE
Add public api key field.

### DIFF
--- a/forms/email/serviceProvider/mailgun.xml
+++ b/forms/email/serviceProvider/mailgun.xml
@@ -7,8 +7,9 @@
 			<field name="username" control="textinput"   required="false" />
 			<field name="password" control="password"    required="false" outputSavedValue="true" />
 
-            <field name="mailgun_api_key"   control="textinput" required="false" />
-            <field name="mailgun_test_mode" control="yesNoSwitch" />
+            <field name="mailgun_api_key"        control="textinput" required="false" />
+            <field name="mailgun_api_public_key" control="textinput" required="false" />
+            <field name="mailgun_test_mode"      control="yesNoSwitch" />
         </fieldset>
     </tab>
 </form>

--- a/i18n/email/serviceProvider/mailgun.properties
+++ b/i18n/email/serviceProvider/mailgun.properties
@@ -13,6 +13,9 @@ field.password.title=Password
 field.mailgun_api_key.title=API Key
 field.mailgun_api_key.placeholder=e.g. key-j3l465j9nlj45i9jlkj9-5lk4j56-gb7
 field.mailgun_api_key.help=The API key is used to validate web hooks. Web hooks will not work without a valid configured API key
+field.mailgun_api_public_key.title=Public API Key
+field.mailgun_api_public_key.placeholder=e.g. pubkey-1j2h3h1j2k3j4h5j3o2i3k4n3b21v321
+field.mailgun_api_public_key.help=Do not use your Mailgun private API key on publicly accessible code. Instead, use your Mailgun public key, available in the My Account tab of the Control Panel.
 
 field.mailgun_test_mode.title=Test mode
 field.mailgun_test_mode.help=Whether or not emails are actually sent to recipients or sending is only faked.

--- a/services/MailgunApiService.cfc
+++ b/services/MailgunApiService.cfc
@@ -805,6 +805,7 @@ component {
 
 			request._mailgunServiceProviderSettings = {
 				  mailgun_api_key        = settings.mailgun_api_key        ?: ""
+				, mailgun_api_public_key = settings.mailgun_api_public_key ?: ""
 				, mailgun_default_domain = settings.mailgun_default_domain ?: ""
 				, mailgun_test_mode      = settings.mailgun_test_mode      ?: ""
 			};

--- a/services/MailgunNotificationsService.cfc
+++ b/services/MailgunNotificationsService.cfc
@@ -125,6 +125,7 @@ component {
 
 			request._mailgunServiceProviderSettings = {
 				  mailgun_api_key        = settings.mailgun_api_key        ?: ""
+				, mailgun_api_public_key = settings.mailgun_api_public_key ?: ""
 				, mailgun_default_domain = settings.mailgun_default_domain ?: ""
 				, mailgun_test_mode      = settings.mailgun_test_mode      ?: ""
 			};


### PR DESCRIPTION
Hi @DominicWatson, I added the public api key field that is needed for email validation: http://mailgun-documentation.readthedocs.io/en/latest/api-email-validation.html.

Cheers,
Nick