### PR TITLE
Configurable MailGun API endpoint

### DIFF
--- a/forms/email/serviceProvider/mailgun.xml
+++ b/forms/email/serviceProvider/mailgun.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form i18nBaseUri="email.serviceProvider.mailgun:">
     <tab id="default">
-        <fieldset id="default">
-            <field name="mailgun_api_endpoint"   control="textinput"   required="false" default="https://api.mailgun.net/v3" />
+        <fieldset id="smtp">
             <field name="server"   control="textinput"   required="false" default="smtp.mailgun.org" />
 			<field name="port"     control="spinner"     required="false" default="587" minvalue="1" maxValue="99999" />
 			<field name="username" control="textinput"   required="false" />
 			<field name="password" control="password"    required="false" outputSavedValue="true" />
-
+        </fieldset>
+        <fieldset id="api">
+            <field name="mailgun_api_endpoint"   control="textinput"   required="false" default="https://api.mailgun.net/v3" />
             <field name="mailgun_api_key"        control="textinput" required="false" />
             <field name="mailgun_api_public_key" control="textinput" required="false" />
             <field name="mailgun_default_domain" control="textinput" required="false" maxLength="255" />

--- a/forms/email/serviceProvider/mailgun.xml
+++ b/forms/email/serviceProvider/mailgun.xml
@@ -2,7 +2,8 @@
 <form i18nBaseUri="email.serviceProvider.mailgun:">
     <tab id="default">
         <fieldset id="default">
-			<field name="server"   control="textinput"   required="false" default="smtp.mailgun.org" />
+            <field name="mailgun_api_endpoint"   control="textinput"   required="false" default="https://api.mailgun.net/v3" />
+            <field name="server"   control="textinput"   required="false" default="smtp.mailgun.org" />
 			<field name="port"     control="spinner"     required="false" default="587" minvalue="1" maxValue="99999" />
 			<field name="username" control="textinput"   required="false" />
 			<field name="password" control="password"    required="false" outputSavedValue="true" />

--- a/i18n/email/serviceProvider/mailgun.properties
+++ b/i18n/email/serviceProvider/mailgun.properties
@@ -2,7 +2,8 @@ title=MailGun
 description=A sending provider for that sends email through the MailGun sending API
 iconclass=fa-envelope
 
-fieldset.default.description=Note that we do not currently send through the mailgun API due to performance issues (it is far slower than sending through native SMTP). Retrieve your SMTP details from the mailgun web interface and enter below.
+fieldset.smtp.title=SMTP settings
+fieldset.smtp.description=Note that we do not currently send through the mailgun API due to performance issues (it is far slower than sending through native SMTP). Retrieve your SMTP details from the mailgun web interface and enter below.
 
 field.server.title=SMTP Server
 field.server.placeholder=e.g. smtp.mailgun.org
@@ -10,6 +11,7 @@ field.port.title=Port
 field.username.title=Username
 field.password.title=Password
 
+fieldset.api.title=API Settings
 field.mailgun_api_key.title=API Key
 field.mailgun_api_key.placeholder=e.g. key-j3l465j9nlj45i9jlkj9-5lk4j56-gb7
 field.mailgun_api_key.help=The API key is used to validate web hooks. Web hooks will not work without a valid configured API key

--- a/i18n/email/serviceProvider/mailgun.properties
+++ b/i18n/email/serviceProvider/mailgun.properties
@@ -22,3 +22,7 @@ field.mailgun_default_domain.help=The default MailGun registered domain to use f
 
 field.mailgun_test_mode.title=Test mode
 field.mailgun_test_mode.help=Whether or not emails are actually sent to recipients or sending is only faked.
+
+field.mailgun_api_endpoint.title=API Endpoint
+field.mailgun_default_domain.help=The default MailGun api endpoint to use for sending mail (without a trailing slash)
+field.mailgun_default_domain.placeholder=e.g. https://api.mailgun.net/v3

--- a/i18n/email/serviceProvider/mailgun_de.properties
+++ b/i18n/email/serviceProvider/mailgun_de.properties
@@ -2,13 +2,16 @@ title=MailGun
 description=Ein Provider f\u00FCr den Versand von E-Mails \u00FCber die MailGun Sending API
 iconclass=fa-envelope
 
-fieldset.default.description=Beachten Sie, dass wir derzeit aus Performancegr\u00FCnden nicht \u00FCber die MailGun API senden (sie ist viel langsamer als das Senden \u00FCber natives SMTP). Rufen Sie Ihre SMTP-Details von der MailGun-Website ab und geben Sie sie unten ein.
+fieldset.smtp.title=SMTP-Einstellungen
+fieldset.smtp.description=Beachten Sie, dass wir derzeit aus Performancegr\u00FCnden nicht \u00FCber die MailGun API senden (sie ist viel langsamer als das Senden \u00FCber natives SMTP). Rufen Sie Ihre SMTP-Details von der MailGun-Website ab und geben Sie sie unten ein.
 
 field.server.title=SMTP-Server
 field.server.placeholder=e.g. smtp.mailgun.org
 field.port.title=Port
 field.username.title=Benutzername
 field.password.title=Passwort
+
+fieldset.api.title=API-Einstellungen
 
 field.mailgun_api_key.title=API-Key
 field.mailgun_api_key.placeholder=z.B. key-j3l465j9nlj45i9jlkj9-5lk4j56-gb7

--- a/i18n/email/serviceProvider/mailgun_de.properties
+++ b/i18n/email/serviceProvider/mailgun_de.properties
@@ -22,3 +22,7 @@ field.mailgun_default_domain.help=Die standardm\u00E4ssig bei MailGun registrier
 
 field.mailgun_test_mode.title=Testmodus
 field.mailgun_test_mode.help=Angabe ob die E-Mails tats\u00E4chlich an die Empf\u00E4nger gesendet werden oder der Versand nur simuliert wird.
+
+field.mailgun_api_endpoint.title=API-Endpunkt 
+field.mailgun_default_domain.help=Die standardm\u00E4ssig bei MailGun API-Endpunkt f\u00FCr den Mailversand (ohne abschließenden Schrägstrich) 
+field.mailgun_default_domain.placeholder=z.B. https://api.mailgun.net/v3

--- a/services/MailgunApiService.cfc
+++ b/services/MailgunApiService.cfc
@@ -830,6 +830,7 @@ component {
 				, mailgun_api_public_key = settings.mailgun_api_public_key ?: ""
 				, mailgun_default_domain = settings.mailgun_default_domain ?: ""
 				, mailgun_test_mode      = settings.mailgun_test_mode      ?: ""
+				, mailgun_api_endpoint   = settings.mailgun_api_endpoint   ?: ""
 			};
 		}
 

--- a/services/MailgunApiService.cfc
+++ b/services/MailgunApiService.cfc
@@ -10,11 +10,9 @@ component {
 	 */
 	public any function init(
 		  required any     emailServiceProviderService
-		,          string  baseUrl       = "https://api.mailgun.net/v3"
 		,          numeric httpsTimeout  = 60
 	) {
 		_setEmailServiceProviderService( arguments.emailServiceProviderService );
-		_setBaseUrl( arguments.baseUrl );
 		_setHttpTimeout( arguments.httpsTimeout );
 
 		return this;
@@ -843,12 +841,11 @@ component {
 	   return LCase( YesNoFormat( arguments.bool ) );
 	}
 
-	private void function _setBaseUrl( required string baseUrl ) {
-		_baseUrl = arguments.baseUrl;
-	}
-
 	private string function _getBaseUrl() {
-		return _baseUrl;
+
+		_baseUrl = _getSettings().mailgun_api_endpoint;
+
+		return len( _baseUrl ) ? _baseUrl : "https://api.mailgun.net/v3" ;
 	}
 
 	private void function _setHttpTimeout( required string httpsTimeout ) {


### PR DESCRIPTION
Configurable API endpoint base url to allow user to specify region to send the email from

https://documentation.mailgun.com/en/latest/api-intro.html#base-url

